### PR TITLE
Fix issue where Sub-commands: would show where no definition items exist...

### DIFF
--- a/sphinxarg/ext.py
+++ b/sphinxarg/ext.py
@@ -122,7 +122,7 @@ def print_command_args_and_opts(arg_list, opt_list, sub_list=None):
             nodes.definition('', opt_list)
         ))
 
-    if sub_list:
+    if sub_list and len(sub_list):
         items.append(nodes.definition_list_item('',
             nodes.term(text='Sub-commands:'),
             nodes.definition('', sub_list)


### PR DESCRIPTION
https://github.com/tony/tmuxp/blob/a07a8fb638979d/tmuxp/cli.py#L688  Here is my parser. It's a little complicated.  I figured you could look at it, in case it was me using `argparse` incorrectly.

When I use the config like:

``` rest

.. argparse::
   :module: tmuxp.cli
   :func: get_parser
   :prog: tmuxp
   :path: load
```

Or any usage _with_ `:path:` as an option.

_without_ `:path:`, this works as expected. My subcommands for `tmuxp load`, `tmuxp import`, etc show.
