### PR TITLE
Display parser description and epilog text

### DIFF
--- a/sphinxarg/ext.py
+++ b/sphinxarg/ext.py
@@ -193,8 +193,6 @@ class ArgParseDirective(Directive):
 
     option_spec = dict(module=unchanged, func=unchanged, prog=unchanged, path=unchanged)
 
-
-
     def run(self):
 
         mod = __import__(self.options['module'], globals(), locals(), [self.options['func']])
@@ -222,6 +220,9 @@ class ArgParseDirective(Directive):
             if not isinstance(item, nodes.definition_list):
                 items.append(item)
 
+        if 'description' in result:
+            items.append(nodes.paragraph(text=result['description']))
+
         items.append(nodes.literal_block(text=result['usage']))
 
         items.append(print_command_args_and_opts(
@@ -230,6 +231,8 @@ class ArgParseDirective(Directive):
             print_subcommand_list(result, nested_content)
         ))
 
+        if 'epilog' in result:
+            items.append(nodes.paragraph(text=result['epilog']))
 
         return items
 

--- a/sphinxarg/parser.py
+++ b/sphinxarg/parser.py
@@ -35,10 +35,26 @@ def parser_navigate(parser_result, path, current_path=None):
     ))
 
 
+def _try_add_parser_attribute(data, parser, attribname):
+
+    attribval = getattr(parser, attribname, None)
+    if attribval is None:
+        return
+
+    if not isinstance(attribval, str):
+        return
+
+    if len(attribval) > 0:
+        data[attribname] = attribval
+
+
 def parse_parser(parser, data=None):
 
     if data is None:
         data = {'name': '', 'usage': parser.format_usage()}
+
+    _try_add_parser_attribute(data, parser, 'description')
+    _try_add_parser_attribute(data, parser, 'epilog')
 
     for action in parser._get_positional_actions():
 

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -42,6 +42,28 @@ def test_parse_positional():
     ]
 
 
+def test_parse_description():
+    parser = argparse.ArgumentParser(description='described', epilog='epilogged')
+    parser.add_argument('foo', default=False, help='foo help')
+    parser.add_argument('bar', default=False)
+
+    data = parse_parser(parser)
+
+    assert data['description'] == 'described'
+
+    assert data['epilog'] == 'epilogged'
+
+    assert data['args'] == [
+        {
+            'name': 'foo',
+            'help': 'foo help'
+        }, {
+            'name': 'bar',
+            'help': ''
+        },
+    ]
+
+
 def test_parse_nested():
     parser = argparse.ArgumentParser()
     parser.add_argument('foo', default=False, help='foo help')


### PR DESCRIPTION
Hello, this code adds support for the description and epilog properties of the ArgumentParser.  Another user reported the wish for epilog support in Issue #4.

I had trouble running the nest parser test on my machine.  I don't believe that is related to these changes though.
