### PR TITLE
Remove the ugly new line in the end of usage str

### DIFF
--- a/sphinxarg/parser.py
+++ b/sphinxarg/parser.py
@@ -48,7 +48,7 @@ def _try_add_parser_attribute(data, parser, attribname):
 
 def parse_parser(parser, data=None, **kwargs):
     if data is None:
-        data = {'name': '', 'usage': parser.format_usage()}
+        data = {'name': '', 'usage': parser.format_usage().strip()}
 
     _try_add_parser_attribute(data, parser, 'description')
     _try_add_parser_attribute(data, parser, 'epilog')


### PR DESCRIPTION
format_usage() returns a string with a new line character in the end, so that it is not prettily displayed in HTML literal block.
