### PR TITLE
Issue #11.  Use built-in sphinx errors and check for function existence.

### DIFF
--- a/sphinxarg/ext.py
+++ b/sphinxarg/ext.py
@@ -210,9 +210,12 @@ class ArgParseDirective(Directive):
             module_name = '.'.join(_parts[0:-1])
             attr_name = _parts[-1]
         else:
-            raise ValueError(':module: and :func: should be specified, or :ref:')
+            raise self.error(':module: and :func: should be specified, or :ref:')
 
         mod = __import__(module_name, globals(), locals(), [attr_name])
+        if not hasattr(mod, attr_name):
+            raise self.error('Module "%s" has no attribute "%s"\nIncorrect argparse :module: or :func: values?' % (module_name, attr_name))
+
         func = getattr(mod, attr_name)
 
         if isinstance(func, ArgumentParser):


### PR DESCRIPTION
This was my fix for Issue #11.  The builtin sphinx errors are used and the existence of the function is tested in the module.

Error output has this appearance, which includes source and line number

pickling environment... C:\Src\Git\nornir-buildmanager\nornir_buildmanager\build.py:docstring of nornir_buildmanager.build:5: ERROR: Module "nornir_buildmanager.build" has no attribute "BuildParserRootfs"
Incorrect argparse :module: or :func: values?
C:\Src\Git\nornir-buildmanager\nornir_buildmanager\build.py:docstring of nornir_buildmanager.build:5: ERROR: Module "nornir_buildmanager.build" has no attribute "BuildParserRootfs"
Incorrect argparse :module: or :func: values?
done
