### PR TITLE
Support for aliasing arguments

### DIFF
--- a/sphinxarg/ext.py
+++ b/sphinxarg/ext.py
@@ -133,6 +133,8 @@ def print_subcommand_list(data, nested_content):
             my_def = apply_definition(definitions, my_def, name)
             if len(my_def) == 0:
                 my_def.append(nodes.paragraph(text='Undocumented'))
+            if 'description' in child:
+                my_def.append(nodes.paragraph(text=child['description']))
             my_def.append(nodes.literal_block(text=child['usage']))
             my_def.append(print_command_args_and_opts(
                 print_arg_list(child, nested_content),

--- a/sphinxarg/ext.py
+++ b/sphinxarg/ext.py
@@ -136,7 +136,8 @@ def print_subcommand_list(data, nested_content):
             my_def.append(nodes.literal_block(text=child['usage']))
             my_def.append(print_command_args_and_opts(
                 print_arg_list(child, nested_content),
-                print_opt_list(child, nested_content)
+                print_opt_list(child, nested_content),
+                print_subcommand_list(child, nested_content)
             ))
             items.append(
                 nodes.definition_list_item(

--- a/sphinxarg/parser.py
+++ b/sphinxarg/parser.py
@@ -86,14 +86,12 @@ def parse_parser(parser, data=None, **kwargs):
                 subdata = {
                     'name': name if not subalias else
                             '%s (%s)' % (name, ', '.join(subalias)),
-                    'help': helps[name] if name in helps else '',
+                    'help': helps.get(name, ''),
                     'usage': subaction.format_usage().strip(),
                     'bare_usage': _format_usage_without_prefix(subaction),
                 }
                 parse_parser(subaction, subdata, **kwargs)
-                if 'children' not in data:
-                    data['children'] = []
-                data['children'].append(subdata)
+                data.setdefault('children', []).append(subdata)
             continue
         if 'args' not in data:
             data['args'] = []

--- a/sphinxarg/parser.py
+++ b/sphinxarg/parser.py
@@ -66,10 +66,26 @@ def parse_parser(parser, data=None, **kwargs):
             helps = {}
             for item in action._choices_actions:
                 helps[item.dest] = item.help
+
+            # commands which share an existing parser are an alias,
+            # don't duplicate docs
+            subsection_alias = {}
+            subsection_alias_names = set()
             for name, subaction in action._name_parser_map.items():
+                if subaction not in subsection_alias:
+                    subsection_alias[subaction] = []
+                else:
+                    subsection_alias[subaction].append(name)
+                    subsection_alias_names.add(name)
+
+            for name, subaction in action._name_parser_map.items():
+                if name in subsection_alias_names:
+                    continue
+                subalias = subsection_alias[subaction]
                 subaction.prog = '%s %s' % (parser.prog, name)
                 subdata = {
-                    'name': name,
+                    'name': name if not subalias else
+                            '%s (%s)' % (name, ', '.join(subalias)),
                     'help': helps[name] if name in helps else '',
                     'usage': subaction.format_usage().strip(),
                     'bare_usage': _format_usage_without_prefix(subaction),


### PR DESCRIPTION
Without this, the same argument would have its full documentation written for each alias.

This solves ticket #21 

Now the command shows:
> command (alias1, alias2)

Instead of of each alias having its own duplicated docs.