### PR TITLE
failing gracefully in case the given module could not be imported

### DIFF
--- a/sphinxarg/ext.py
+++ b/sphinxarg/ext.py
@@ -321,7 +321,13 @@ class ArgParseDirective(Directive):
         else:
             raise self.error(
                 ':module: and :func: should be specified, or :ref:')
-        mod = __import__(module_name, globals(), locals(), [attr_name])
+
+        # failing gracefully in case the given module could not be imported
+        try:
+            mod = __import__(module_name, globals(), locals(), [attr_name])
+        except ImportError as e:
+            raise self.error('Failed to import "%s" from "%s": %s' % (attr_name, module_name, e))
+
         if not hasattr(mod, attr_name):
             raise self.error((
                 'Module "%s" has no attribute "%s"\n'


### PR DESCRIPTION
Hello there!
First of all, many thanks for creating this great library.

I used it in my project but pointed the `:ref:` to an invalid python module of mine (it was missing a `__init__.py`), then **sphinx-argparse** raised an exception whose message was not helpful at all.

This patch provides a much more descriptive output, for example:


```
/home/..redacted../docs/source/cli.rst:33: ERROR: Failed to import "MyPythonProject.console.parsers.command1" from "parser": No module named parsers.command1
/home/..redacted../docs/source/cli.rst:33: ERROR: Failed to import "MyPythonProject.console.parsers.command2" from "parser": No module named parsers.command2
```