### PR TITLE
Add a :nodefaultconst: directive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "2.7"
   - "3.3"
 install:
-- "pip install -e .[dev] --use-mirrors"
+- "pip install -e .[dev]"
 
 script:
 - py.test

--- a/sphinxarg/ext.py
+++ b/sphinxarg/ext.py
@@ -156,6 +156,7 @@ class ArgParseDirective(Directive):
     has_content = True
     option_spec = dict(module=unchanged, func=unchanged, ref=unchanged,
                        prog=unchanged, path=unchanged, nodefault=flag,
+                       nodefaultconst=flag,
                        manpage=unchanged, nosubcommands=unchanged, passparser=flag)
 
     def _construct_manpage_specific_structure(self, parser_info):
@@ -341,7 +342,7 @@ class ArgParseDirective(Directive):
         if 'prog' in self.options:
             parser.prog = self.options['prog']
         result = parse_parser(
-            parser, skip_default_values='nodefault' in self.options)
+            parser, skip_default_values='nodefault' in self.options, skip_default_const_values='nodefaultconst' in self.options)
         result = parser_navigate(result, path)
         if 'manpage' in self.options:
             return self._construct_manpage_specific_structure(result)

--- a/sphinxarg/parser.py
+++ b/sphinxarg/parser.py
@@ -1,4 +1,4 @@
-from argparse import _HelpAction, _SubParsersAction
+from argparse import _HelpAction, _SubParsersAction, _StoreConstAction
 import re
 
 
@@ -106,16 +106,26 @@ def parse_parser(parser, data=None, **kwargs):
     show_defaults = (
         ('skip_default_values' not in kwargs)
         or (kwargs['skip_default_values'] is False))
+    show_defaults_const = show_defaults
+    if 'skip_default_const_values' in kwargs and kwargs['skip_default_const_values'] is True:
+        show_defaults_const = False
     for action in parser._get_optional_actions():
         if isinstance(action, _HelpAction):
             continue
         if 'options' not in data:
             data['options'] = []
-        option = {
-            'name': action.option_strings,
-            'default': action.default if show_defaults else '==SUPPRESS==',
-            'help': action.help or ''
-        }
+        if isinstance(action, _StoreConstAction):
+            option = {
+                'name': action.option_strings,
+                'default': action.default if show_defaults_const else '==SUPPRESS==',
+                'help': action.help or ''
+            }
+        else:
+            option = {
+                'name': action.option_strings,
+                'default': action.default if show_defaults else '==SUPPRESS==',
+                'help': action.help or ''
+            }
         if action.choices:
             option['choices'] = action.choices
         if "==SUPPRESS==" not in option['help']:


### PR DESCRIPTION
At least in our usage, it'd be really nice to suppress the "default" value when `action='store_true'` (or store_false or store_const) are used but to keep displaying it in all other cases. This is mostly because people never seem to send us emails saying they're confused by `--foo=42`, but do if they see `--foo=False`, since then they wonder whether they actually need to type `--foo=False` if they want the `--foo` option or not. Adding a `:nodefaultconst:` directive would make that clearer.