### PR TITLE
ext: Support relative path for filename option

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -45,7 +45,9 @@ To document a file that is not part of a module, use :filename::
        :filename: script.py
        :func: my_func_that_returns_a_parser
        :prog: script.py
-        
+
+The 'filename' option could be absolute path or a relative path under current
+working dir.
 
 \:module\:
     Module name, where the function is located

--- a/sphinxarg/ext.py
+++ b/sphinxarg/ext.py
@@ -333,7 +333,11 @@ class ArgParseDirective(Directive):
             attr_name = _parts[-1]
         elif 'filename' in self.options and 'func' in self.options:
             mod = {}
-            f = open(self.options['filename'])
+            try:
+                f = open(self.options['filename'])
+            except IOError:
+                # try open with abspath
+                f = open(os.path.abspath(self.options['filename']))
             code = compile(f.read(), self.options['filename'], 'exec')
             exec(code, mod)
             attr_name = self.options['func']


### PR DESCRIPTION
If filename option is given, the open file operation will fail if
given a relative path name under current os.path, try to open
again with abspath.

Signed-off-by: Wayne Sun <gsun@redhat.com>