### PR TITLE
Provide directive settings for renderList

### DIFF
--- a/sphinxarg/ext.py
+++ b/sphinxarg/ext.py
@@ -52,7 +52,7 @@ def map_nested_definitions(nested_content):
     return definitions
 
 
-def renderList(l, markDownHelp):
+def renderList(l, markDownHelp, settings=None):
     """
     Given a list of reStructuredText or MarkDown sections, return a docutils node list
     """
@@ -61,13 +61,14 @@ def renderList(l, markDownHelp):
     if markDownHelp:
         return parseMarkDownBlock('\n\n'.join(l) + '\n')
     else:
-        settings = OptionParser(components=(Parser,)).get_default_values()
+        if settings is None:
+            settings = OptionParser(components=(Parser,)).get_default_values()
         document = new_document(None, settings)
         Parser().parse('\n\n'.join(l) + '\n', document)
         return document.children
 
 
-def print_action_groups(data, nested_content, markDownHelp=False):
+def print_action_groups(data, nested_content, markDownHelp=False, settings=None):
     """
     Process all 'action groups', which are also include 'Options' and 'Required
     arguments'. A list of nodes is returned.
@@ -142,7 +143,7 @@ def print_action_groups(data, nested_content, markDownHelp=False):
 
                 n = nodes.option_list_item('',
                                            nodes.option_group('', nodes.option_string(text=term)),
-                                           nodes.description('', *renderList(desc, markDownHelp)))
+                                           nodes.description('', *renderList(desc, markDownHelp, settings)))
                 items.append(n)
 
             section += nodes.option_list('', *items)
@@ -476,7 +477,8 @@ class ArgParseDirective(Directive):
             else:
                 items.append(self._nested_parse_paragraph(result['description']))
         items.append(nodes.literal_block(text=result['usage']))
-        items.extend(print_action_groups(result, nested_content, markDownHelp))
+        items.extend(print_action_groups(result, nested_content, markDownHelp,
+                                         settings=self.state.document.settings))
         if 'nosubcommands' not in self.options:
             items.extend(print_subcommands(result, nested_content, markDownHelp))
         if 'epilog' in result and 'noepilog' not in self.options:


### PR DESCRIPTION
This is a bug fix to mainly fix sphinx roles that are provided in an argparse parser. Consider the following very simple example:

``conf.py``
```python
import sys
import os.path as osp

sys.path.insert(0, osp.abspath(osp.dirname(__file__)))

extensions = ['sphinx.ext.autodoc', 'sphinxarg.ext']
```

``test.py``
```python
from argparse import ArgumentParser


def my_function():
    """Dummy function"""
    pass


def get_parser():
    """Create the parser"""
    parser = ArgumentParser()
    parser.add_argument(
        '-t', help="Some cross reference to :func:`test.my_function`")
    return parser
```

``contents.rst``
```rst
Index file
==========

.. toctree::


.. automodule:: test
    :members:
    :undoc-members:
    :show-inheritance:

.. argparse::
   :module: test
   :func: get_parser
   :prog: test
```
The point here is, that the parser contains a cross-reference to the ``my_function`` function. 
Without the provided bug fix, this raises an ``AttributeError: 'Values' object has no attribute 'env'`` when running ``sphinx-build`` because the ``settings`` object in the ``renderList`` function does not have the ``env`` attribute. That is because it is created as a new ``OptionParser`` instance. Instead, it should use the settings from the ``Sphinx`` app that is provided to the ``ArgParseDirective``.

With the provided bug fix, it instead inserts a link into the documentation to the documentation of the ``my_function`` function from above (see ``contents.html`` [html.zip](https://github.com/ribozz/sphinx-argparse/files/887627/html.zip))
