### PR TITLE
Made markdown module optional to fix builds on RTD

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ For installation and usage details, see the `documentation <http://sphinx-argpar
     ],
     install_requires=[
         'sphinx>=1.2.0',
-        'CommonMark>=0.5.6'
+        'CommonMark'
     ],
     extras_require={
         'dev': ['pytest', 'sphinx_rtd_theme']

--- a/sphinxarg/ext.py
+++ b/sphinxarg/ext.py
@@ -57,6 +57,7 @@ def renderList(l, markDownHelp, settings=None):
     if len(l) == 0:
         return []
     if markDownHelp:
+        from sphinxarg.markdown import parseMarkDownBlock
         return parseMarkDownBlock('\n\n'.join(l) + '\n')
     else:
         if settings is None:

--- a/sphinxarg/ext.py
+++ b/sphinxarg/ext.py
@@ -10,7 +10,6 @@ from docutils.frontend import OptionParser
 from sphinx.util.nodes import nested_parse_with_titles
 
 from sphinxarg.parser import parse_parser, parser_navigate
-from sphinxarg.markdown import parseMarkDownBlock
 
 
 def map_nested_definitions(nested_content):
@@ -457,6 +456,7 @@ class ArgParseDirective(Directive):
         items = []
         nested_content = nodes.paragraph()
         if 'markdown' in self.options:
+            from sphinxarg.markdown import parseMarkDownBlock
             items.extend(parseMarkDownBlock('\n'.join(self.content) + '\n'))
         else:
             self.state.nested_parse(

--- a/sphinxarg/ext.py
+++ b/sphinxarg/ext.py
@@ -150,7 +150,7 @@ def print_action_groups(data, nested_content, markDownHelp=False, settings=None)
     return nodes_list
 
 
-def print_subcommands(data, nested_content, markDownHelp=False):
+def print_subcommands(data, nested_content, markDownHelp=False, settings=None):
     """
     Each subcommand is a dictionary with the following keys:
 
@@ -191,10 +191,12 @@ def print_subcommands(data, nested_content, markDownHelp=False):
             for element in renderList(desc, markDownHelp):
                 sec += element
             sec += nodes.literal_block(text=child['bare_usage'])
-            for x in print_action_groups(child, nested_content + subContent, markDownHelp):
+            for x in print_action_groups(child, nested_content + subContent, markDownHelp,
+                                         settings=settings):
                 sec += x
 
-            for x in print_subcommands(child, nested_content + subContent, markDownHelp):
+            for x in print_subcommands(child, nested_content + subContent, markDownHelp,
+                                       settings=settings):
                 sec += x
 
             subCommands += sec
@@ -479,7 +481,8 @@ class ArgParseDirective(Directive):
         items.extend(print_action_groups(result, nested_content, markDownHelp,
                                          settings=self.state.document.settings))
         if 'nosubcommands' not in self.options:
-            items.extend(print_subcommands(result, nested_content, markDownHelp))
+            items.extend(print_subcommands(result, nested_content, markDownHelp,
+                                           settings=self.state.document.settings))
         if 'epilog' in result and 'noepilog' not in self.options:
             items.append(self._nested_parse_paragraph(result['epilog']))
 


### PR DESCRIPTION
This PR intends to fix https://github.com/ribozz/sphinx-argparse/issues/74 and https://github.com/rtfd/readthedocs.org/issues/3032

The above issues are now open for several months already and it is not sure, when they will be closed. 

The changes proposed here simply only import the [markdown](https://github.com/ribozz/sphinx-argparse/blob/master/sphinxarg/markdown.py) module if and only if the `:markdownhelp:` flag is set. Without this flag, the dependency on Commonmark is purely optional. This then would allow to use sphinx-argparse on RTD again, even though we have CommonMark < 0.5.6.

The second commit completes the work done by PR https://github.com/ribozz/sphinx-argparse/pull/61 and also provides the directive settings to the `print_subcommands` function.