### PR TITLE
Try commonmark, fall back to CommonMark.

### DIFF
--- a/sphinxarg/markdown.py
+++ b/sphinxarg/markdown.py
@@ -1,5 +1,11 @@
-from CommonMark import Parser  # >= 0.5.6
-from CommonMark.node import Node
+try:
+    from commonmark import Parser
+except ImportError:
+    from CommonMark import Parser  # >= 0.5.6
+try:
+    from commonmark.node import Node
+except ImportError:
+    from CommonMark.node import Node
 from docutils import nodes
 from docutils.utils.code_analyzer import Lexer
 


### PR DESCRIPTION
Version 0.8.0 change the name of the module to commonmark to help with pep8. Version 0.8.1 removed the old style CommonMark. This patch tries the commonmark module and falls back to loading the old style if it raises ImportError.