### PR TITLE
fix iterating over subContent

### DIFF
--- a/sphinxarg/ext.py
+++ b/sphinxarg/ext.py
@@ -93,8 +93,9 @@ def print_action_groups(data, nested_content, markDownHelp=False, settings=None)
                     desc.append(s)
                 elif classifier == '@before':
                     desc.insert(0, s)
-                for k, v in subContent.items():
-                    definitions[k] = v
+                if len(subContent) > 0:
+                    for k, v in map_nested_definitions(subContent).items():
+                        definitions[k] = v
             # Render appropriately
             for element in renderList(desc, markDownHelp):
                 section += element
@@ -102,7 +103,7 @@ def print_action_groups(data, nested_content, markDownHelp=False, settings=None)
             localDefinitions = definitions
             if len(subContent) > 0:
                 localDefinitions = {k: v for k, v in definitions.items()}
-                for k, v in map_nested_definitions(subContent):
+                for k, v in map_nested_definitions(subContent).items():
                     localDefinitions[k] = v
 
             items = []


### PR DESCRIPTION
when trying to @replace a command group, the following exception was
raised:

    Exception occurred:
      File "/usr/lib/python3.6/site-packages/sphinxarg/ext.py", line 96, in print_action_groups
        for k, v in subContent.items():
    AttributeError: 'list' object has no attribute 'items'

and later

    Exception occurred:
      File "/usr/lib/python3.6/site-packages/sphinxarg/ext.py", line 105, in print_action_groups
        for k, v in map_nested_definitions(subContent):
    ValueError: too many values to unpack (expected 2)