### PR TITLE
allow skipping sections

### DIFF
--- a/docs/extend.rst
+++ b/docs/extend.rst
@@ -62,6 +62,9 @@ You can also add classifiers, which will change how these definitions are incorp
             --upgrade : @after
                 The after directive is the default, so you needn't specify it.
 
+       advanced arguments : @skip
+            skip advanced arguments
+
 
 @before
     Insert content before the parsed help/description message of the argument/option/subcommand/argument-group.
@@ -71,3 +74,6 @@ You can also add classifiers, which will change how these definitions are incorp
 
 @replace
     Replace content of help/description message of argument/option/subcommand/argument-group.
+
+@skip
+    Skip the content of help/description message of subcommand/argument-group.

--- a/sphinxarg/ext.py
+++ b/sphinxarg/ext.py
@@ -32,7 +32,7 @@ def map_nested_definitions(nested_content):
                 if len(ci.children) > 0:
                     classifier = ci.children[0].astext()
             if classifier is not None and classifier not in (
-                    '@replace', '@before', '@after'):
+                    '@replace', '@before', '@after', '@skip'):
                 raise Exception('Unknown classifier: %s' % classifier)
             idx = subitem.first_child_matching_class(nodes.term)
             if idx is not None:
@@ -93,6 +93,8 @@ def print_action_groups(data, nested_content, markDownHelp=False, settings=None)
                     desc.append(s)
                 elif classifier == '@before':
                     desc.insert(0, s)
+                elif classifier == '@skip':
+                    continue
                 if len(subContent) > 0:
                     for k, v in map_nested_definitions(subContent).items():
                         definitions[k] = v

--- a/sphinxarg/ext.py
+++ b/sphinxarg/ext.py
@@ -93,8 +93,9 @@ def print_action_groups(data, nested_content, markDownHelp=False, settings=None)
                     desc.append(s)
                 elif classifier == '@before':
                     desc.insert(0, s)
-                for k, v in subContent.items():
-                    definitions[k] = v
+                if len(subContent) > 0:
+                    for k, v in map_nested_definitions(subContent).items():
+                        definitions[k] = v
             # Render appropriately
             for element in renderList(desc, markDownHelp):
                 section += element
@@ -102,7 +103,7 @@ def print_action_groups(data, nested_content, markDownHelp=False, settings=None)
             localDefinitions = definitions
             if len(subContent) > 0:
                 localDefinitions = {k: v for k, v in definitions.items()}
-                for k, v in map_nested_definitions(subContent):
+                for k, v in map_nested_definitions(subContent).items():
                     localDefinitions[k] = v
 
             items = []


### PR DESCRIPTION
this is useful when you have an argument group that is used in all subcommands, but you do not want to repeat it over and over again.

it also kinda depends on #99 ;-)