### PR TITLE
Add support for `type=<class Enum>` to list the possible choices.

### DIFF
--- a/sphinxarg/ext.py
+++ b/sphinxarg/ext.py
@@ -1,6 +1,7 @@
 import sys
 from argparse import ArgumentParser
 import os
+from enum import EnumType
 
 from docutils import nodes
 from docutils.statemachine import StringList
@@ -125,11 +126,15 @@ def print_action_groups(data, nested_content, markDownHelp=False, settings=None)
                     name	A list of option names (e.g., ['-h', '--help']
                     help	The help message string
                 There may also be a 'choices' member.
+                There may also be a 'type' member. If this type is an EnumType
+                then this will be used as possible choices.
                 """
                 # Build the help text
                 arg = []
                 if 'choices' in entry:
                     arg.append('Possible choices: {}\n'.format(", ".join([str(c) for c in entry['choices']])))
+                elif 'type' in entry and isinstance(entry['type'], EnumType):
+                    arg.append('Possible choices: {}\n'.format(', '.join(entry['type'])))
                 if 'help' in entry:
                     arg.append(entry['help'])
                 if entry['default'] is not None and entry['default'] not in ['"==SUPPRESS=="', '==SUPPRESS==']:
@@ -355,6 +360,10 @@ class ArgParseDirective(Directive):
                 arg_items.append(
                     nodes.paragraph(
                         text='Possible choices: ' + ', '.join(arg['choices'])))
+            elif 'type' in arg and isinstance(arg['type'], EnumType):
+                arg_items.append(
+                    nodes.paragraph(
+                        text='Possible choices: ' + ', '.join(arg['type'])))
             items.append(
                 nodes.option_list_item(
                     '',
@@ -387,6 +396,10 @@ class ArgParseDirective(Directive):
                 opt_items.append(
                     nodes.paragraph(
                         text='Possible choices: ' + ', '.join(opt['choices'])))
+            elif 'type' in opt and isinstance(opt['type'], EnumType):
+                opt_items.append(
+                    nodes.paragraph(
+                        text='Possible choices: ' + ', '.join(opt['type'])))
             items.append(
                 nodes.option_list_item(
                     '', nodes.option_group('', *names),

--- a/sphinxarg/parser.py
+++ b/sphinxarg/parser.py
@@ -152,6 +152,8 @@ def parse_parser(parser, data=None, **kwargs):
                 }
             if action.choices:
                 option['choices'] = action.choices
+            if action.type:
+                option['type'] = action.type
             if "==SUPPRESS==" not in option['help']:
                 options_list.append(option)
 


### PR DESCRIPTION
The python `add_argument()` method supports a `type` field which can be set to an Enum class object. Then using the `metavar` field it can be defined to mimic the `choices` field. Then the `prog --help` shows the correct values, and this includes the basic usage in the sphinx-argparse output as well.

However the individual parameter listing for sphinx-argparse does not list the possible choices in the same way as it does for the `choices` field.

This will enable that functionality where if the `type` is set to an `EnumType` instance, then it will append the `Possible Choices` list if there is no `choices` defined already.

# Example Program
```python

"""
test.py

.. argparse::
    :ref: test.argParser
    :prog: test.py
"""

import argparse
from enum import Enum, auto

class someStringEnum(str, Enum):
    value1 = 'value1'
    value2 = 'value2'
    value3 = 'value3'

class someIntEnum(str, Enum):
    int1 = auto()
    int2 = auto()
    int3 = auto()

def argParser():
    parser = argparse.ArgumentParser('description')
    parser.add_argument('--string', type=someStringEnum, help='String based enum', metavar='{' + ','.join(someStringEnum) + '}')
    parser.add_argument('--int', type=someIntEnum, help='Int based enum', metavar='{' + ','.join(someIntEnum) + '}')
    return parser

def main():
    parser = argParser()
    args = parser.parse_args()
    print(args)

if __name__ == '__main__':
    main()
```

# Usage / Help statement and example CLI.
```
$ test.py --help
usage: description [-h] [--string {value1,value2,value3}] [--int {1,2,3}]

options:
  -h, --help            show this help message and exit
  --string {value1,value2,value3}
                        String based enum
  --int {1,2,3}         Int based enum
$ test.py --string unknown
usage: description [-h] [--string {value1,value2,value3}] [--int {1,2,3}]
description: error: argument --string: invalid someStringEnum value: 'unknown'
$ test.py --string value1 --int 2
Namespace(string=<someStringEnum.value1: 'value1'>, int=<someIntEnum.int2: '2'>)
$
```
# Sphinx output
![image](https://github.com/alex-rudakov/sphinx-argparse/assets/3730811/c9b3b326-d4d9-4d69-835b-f90a710a9aed)